### PR TITLE
Replace similar characters

### DIFF
--- a/app.js
+++ b/app.js
@@ -307,6 +307,13 @@ var ngramTypeConfig = {
 
             // Remove spaces at starting of the phrase
             var typedPhrase = this.typedPhrase.trimStart();
+            var substitutions = [
+                ["’", "'"],
+                ["œ", "oe"],
+            ];
+            for (var subst of substitutions) {
+                typedPhrase = typedPhrase.replaceAll(subst[0], subst[1]);
+            }
             if (!typedPhrase.length) {
                 return;
             }


### PR DESCRIPTION
In french, it is better to use ’ instead of ' in many sentences (eg: l’)
Can be extended later with other terms if needed

Let me know if you wish that I make the PR on the main repository instead.

Fixes ranelpadon/ngram-type#39